### PR TITLE
Rework StartContinuousSampling and StartAveragedContinuousSampling

### DIFF
--- a/nanoFramework.GiantGecko.Adc/AdcController.cs
+++ b/nanoFramework.GiantGecko.Adc/AdcController.cs
@@ -135,12 +135,11 @@ namespace nanoFramework.GiantGecko.Adc
         /// Starts continuous sampling on the specified channels using the default <see cref="AdcChannelConfiguration"/>.
         /// </summary>
         /// <param name="channels">Array of channels indexes to scan performing continuous sampling.</param>
-        /// <returns><see langword="true"/> if the operation was successful. <see langword="false"/> otherwise.</returns>
         /// <exception cref="InvalidOperationException">If a previous continuous sampling operation has been started previously without being stopped.</exception>
         /// <exception cref="ArgumentException">If the specified channel index does not exist.</exception>
-        public bool StartContinuousSampling(int[] channels)
+        public void StartContinuousSampling(int[] channels)
         {
-            return StartContinuousSampling(
+            StartContinuousSampling(
                 channels,
                 new AdcChannelConfiguration());
         }
@@ -150,10 +149,9 @@ namespace nanoFramework.GiantGecko.Adc
         /// </summary>
         /// <param name="channels">Array of channels indexes to scan performing continuous sampling.</param>
         /// <param name="configuration">Initial configuration for the various ADC channels.</param>
-        /// <returns><see langword="true"/> if the operation was successful. <see langword="false"/> otherwise.</returns>
         /// <exception cref="InvalidOperationException">If a previous continuous sampling operation has been started previously without being stopped.</exception>
         /// <exception cref="ArgumentException">If the specified channel index does not exist.</exception>
-        public bool StartContinuousSampling(
+        public void StartContinuousSampling(
             int[] channels,
             AdcChannelConfiguration configuration)
         {
@@ -162,12 +160,10 @@ namespace nanoFramework.GiantGecko.Adc
             _adcChannelConfiguration = configuration;
 
             // set average count to 1 for single sample
-            // update flag upon successful start
-            _continuousSamplingStarted = NativeStartContinuousConversion(
-                channels,
-                1);
-
-            return _continuousSamplingStarted;
+            // flag is updated in native code upon successful start
+            NativeStartContinuousConversion(
+                            channels,
+                            1);
         }
 
         /// <summary>
@@ -181,11 +177,11 @@ namespace nanoFramework.GiantGecko.Adc
         /// <returns><see langword="true"/> if the continuous sampling was successfully started. <see langword="false"/> otherwise.</returns>
         /// <exception cref="InvalidOperationException"></exception>
         /// <exception cref="ArgumentException">If the specified channel index does not exist.</exception>
-        public bool StartAveragedContinuousSampling(
+        public void StartAveragedContinuousSampling(
             int[] channels,
             int count)
         {
-            return StartAveragedContinuousSampling(
+            StartAveragedContinuousSampling(
                 channels,
                 new AdcChannelConfiguration(),
                 count);
@@ -203,7 +199,7 @@ namespace nanoFramework.GiantGecko.Adc
         /// <returns><see langword="true"/> if the continuous sampling was successfully started. <see langword="false"/> otherwise.</returns>
         /// <exception cref="InvalidOperationException"></exception>
         /// <exception cref="ArgumentException">If the specified channel index does not exist.</exception>
-        public bool StartAveragedContinuousSampling(
+        public void StartAveragedContinuousSampling(
             int[] channels,
             AdcChannelConfiguration configuration,
             int count)
@@ -214,7 +210,7 @@ namespace nanoFramework.GiantGecko.Adc
 
             // set average count to 1 for single sample
             // flag is updated in native code upon successful start
-            return NativeStartContinuousConversion(
+            NativeStartContinuousConversion(
                 channels,
                 count);
         }
@@ -257,7 +253,7 @@ namespace nanoFramework.GiantGecko.Adc
         private extern SampleResolution[] NativeGetSupportedResolutionsInBits();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private extern bool NativeStartContinuousConversion(
+        private extern void NativeStartContinuousConversion(
             int[] channels,
             int count);
 


### PR DESCRIPTION
## Description
- Now uses an array of channel indexes and optionally a common adc channel configuration.
- Remove field with array of channels.
- Add field with adc channel configuraion.
- Rework code accordingly.
- Native method now accepts channel array as parameter.
- Remove return value on methods where that doesn't make sense.

## Motivation and Context
- Resolves Skyworks-Timing-Software/MCU#6.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
