### PR TITLE
Read value methods now check for ongoing continuous operation

### DIFF
--- a/nanoFramework.GiantGecko.Adc/AdcChannel.cs
+++ b/nanoFramework.GiantGecko.Adc/AdcChannel.cs
@@ -59,6 +59,7 @@ namespace nanoFramework.GiantGecko.Adc
         }
 
         /// <inheritdoc/>
+        /// <exception cref="InvalidOperationException">If a continuous conversion is ongoing in the <see cref="AdcController"/>.</exception>
         public override int ReadValue()
         {
             lock (_syncLock)
@@ -69,12 +70,19 @@ namespace nanoFramework.GiantGecko.Adc
                     throw new ObjectDisposedException();
                 }
 
+                // can't read a channel when performing continuous conversion
+                if (_adcController._continuousSamplingStarted)
+                {
+                    throw new InvalidOperationException();
+                }
+
                 // set average count to 1 for single sample
                 return NativeReadValue(1);
             }
         }
 
         /// <inheritdoc/>
+        /// <exception cref="InvalidOperationException">If a continuous conversion is ongoing in the <see cref="AdcController"/>.</exception>
         public override int ReadValueAveraged(int count)
         {
             lock (_syncLock)
@@ -83,6 +91,12 @@ namespace nanoFramework.GiantGecko.Adc
                 if (_disposed)
                 {
                     throw new ObjectDisposedException();
+                }
+
+                // can't read a channel when performing continuous conversion
+                if (_adcController._continuousSamplingStarted)
+                {
+                    throw new InvalidOperationException();
                 }
 
                 return NativeReadValue(count);

--- a/nanoFramework.GiantGecko.Adc/AdcController.cs
+++ b/nanoFramework.GiantGecko.Adc/AdcController.cs
@@ -22,7 +22,7 @@ namespace nanoFramework.GiantGecko.Adc
         // a lock is required because multiple threads can access the AdcController
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private readonly object _syncLock;
-        private bool _continuousSamplingStarted;
+        internal bool _continuousSamplingStarted;
 
         private readonly AdcConfiguration _adcConfiguration;
         private AdcChannelConfiguration _adcChannelConfiguration;


### PR DESCRIPTION
## Description
- Read value methods now check for ongoing continuous operation.
- Change visibility of `AdcController` field to allow access from `AdcChannel`.

## Motivation and Context
- Without this check the operation would fail on the driver because it's not possible to have both scan and single operations happening simultaneously.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
