### PR TITLE
Remove LastContinuousValue method from AdcChannel

### DIFF
--- a/nanoFramework.GiantGecko.Adc/AdcChannel.cs
+++ b/nanoFramework.GiantGecko.Adc/AdcChannel.cs
@@ -35,17 +35,6 @@ namespace nanoFramework.GiantGecko.Adc
         /// </summary>
         public AdcChannelConfiguration AdcChannelConfiguration => _adcChannelConfiguration;
 
-        /// <summary>
-        /// The last value read in continuous sample mode started via <see cref="AdcController.StartContinuousSampling"/>() or, if averaged sampling continuous mode is currently in use via <see cref="AdcController.StartAveragedContinuousSampling"/>(), the latest averaged value.
-        /// It is an error to read this property if the channel is not currently in continuous mode.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">When reading from this property when the is not currently in continuous mode.</exception>
-        public extern int LastContinuousValue
-        {
-            [MethodImpl(MethodImplOptions.InternalCall)]
-            get;
-        }
-
         internal AdcChannel(
             AdcController controller,
             int channelNumber,


### PR DESCRIPTION
## Description
- Remove `LastContinuousValue` method from `AdcChannel`.

## Motivation and Context
- Since the `AdcChannel` are not opened anymore to start a continuous scan operation, this access to the last sample value doesn't make sense anymore.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
